### PR TITLE
Update frontend agent to reflect correct react skill

### DIFF
--- a/.agent/agents/frontend-specialist.md
+++ b/.agent/agents/frontend-specialist.md
@@ -575,7 +575,7 @@ After editing any file:
 
 ---
 
-> **Note:** This agent loads relevant skills (clean-code, react-best-practices, etc.) for detailed guidance. Apply behavioral principles from those skills rather than copying patterns.
+> **Note:** This agent loads relevant skills (clean-code, nextjs-react-expert, etc.) for detailed guidance. Apply behavioral principles from those skills rather than copying patterns.
 
 ---
 


### PR DESCRIPTION
The frontend skill was formerly referencing the **_react-best-practices_** skill. This does not currently exist in the skills folder.
I replaced that with the _**nextjs-react-expert**_.