### PR TITLE
fix(cli): resolve symlinks when checking direct execution for npx compatibility

### DIFF
--- a/cli/bin/index.js
+++ b/cli/bin/index.js
@@ -3,6 +3,7 @@ import { Command, Option } from "commander";
 import chalk from "chalk";
 import ora from "ora";
 import { downloadTemplate } from "giget";
+import fs from "node:fs";
 import path from "node:path";
 import fse from "fs-extra";
 import readline from "node:readline";
@@ -428,8 +429,15 @@ export const runCli = async (argv = process.argv) => {
     await program.parseAsync(argv);
 };
 
-const isDirectRun = process.argv[1]
-    && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+let isDirectRun = false;
+if (process.argv[1]) {
+    try {
+        const resolvedPath = fs.realpathSync(process.argv[1]);
+        isDirectRun = pathToFileURL(resolvedPath).href === import.meta.url;
+    } catch {
+        isDirectRun = pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+    }
+}
 
 if (isDirectRun) {
     process.on("SIGINT", async () => {

--- a/cli/test/index.test.js
+++ b/cli/test/index.test.js
@@ -2,6 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { buildProgram } from "../bin/index.js";
 
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+const execFileAsync = promisify(execFile);
+
 test("CLI exposes safe lifecycle commands", () => {
     const program = buildProgram();
     const commands = new Map(program.commands.map((command) => [command.name(), command]));
@@ -10,4 +18,18 @@ test("CLI exposes safe lifecycle commands", () => {
     assert.ok(commands.get("update").options.some((option) => option.long === "--strategy"));
     assert.ok(commands.get("update").options.some((option) => option.long === "--dry-run"));
     assert.ok(commands.get("rollback").options.some((option) => option.long === "--backup"));
+});
+
+test("CLI executes when invoked via symlink (npx simulation)", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ag-kit-symlink-test-"));
+    const symlinkPath = path.join(tempDir, "ag-kit-bin");
+    const binPath = path.resolve("bin/index.js");
+
+    try {
+        await fs.symlink(binPath, symlinkPath);
+        const { stdout } = await execFileAsync(symlinkPath, ["--version"]);
+        assert.ok(stdout.trim().length > 0, "CLI output should not be empty when invoked via symlink");
+    } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+    }
 });


### PR DESCRIPTION
## Summary
Fixes an issue where running `npx @vudovn/ag-kit init` (or executing `ag-kit` via a symlink in `node_modules/.bin` on macOS / Linux) exits silently without running the CLI.

## Current Behavior
Running `npx @vudovn/ag-kit init` exits immediately with status code `0`, outputs no text or errors to stdout/stderr, and fails to create `.agents`.

## Expected Behavior
Running `npx @vudovn/ag-kit init` displays the CLI banner, downloads the toolkit, and installs `.agents` into the target project directory.

## Root Cause
When Node.js executes a script via `npx` or a symlink:
- `process.argv[1]` contains the symlink path (e.g., `~/.npm/_npx/.../.bin/ag-kit`).
- `import.meta.url` resolves to the canonical target URL (`file:///.../cli/bin/index.js`).
- `path.resolve(process.argv[1])` does not resolve filesystem symlinks, causing `pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url` to evaluate to `false`.
- Consequently, `isDirectRun` was `false` and `runCli()` was never invoked.

## Changes
- Used `fs.realpathSync(process.argv[1])` to resolve symlinks before comparing file URLs with `import.meta.url` (with fallback to `path.resolve`).
- Added an automated unit test in `cli/test/index.test.js` simulating `npx` symlink execution.

## Testing
- All 12 CLI unit tests pass (`npm --prefix cli test`).
- Verified execution via symlinks and `npx`.