### PR TITLE
fix(antigravity): align native hook configuration and decisions

### DIFF
--- a/.agents/CHANGELOG.md
+++ b/.agents/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Clearly separated stable core features from opt-in Tasks, Skills over MCP, and MCP Apps extensions.
 - Reworked the orchestrator and `parallel-agents` guidance around Antigravity-native agents and tasks while retaining best-effort portability for other runtimes.
 - Removed Claude-specific built-in agent and model-tier assumptions from managed orchestration instructions; runtime capabilities must now be discovered before delegation.
+- Migrated workspace hooks to Antigravity's named-hook format with nested command handlers.
+- Updated Antigravity Doctor and regression tests to validate the native hook structure and JSON decision contract.
 
 ### Security
 
@@ -15,6 +17,7 @@
 - Added explicit trust boundaries for repository content, MCP responses, tool annotations, web content, logs, and subagent outputs.
 - Added finite agent, delegation-depth, turn/retry, timeout, cancellation, and no-progress controls to prevent recursive delegation and indefinite ReAct loops.
 - Parallel writers now require isolated worktrees, sandboxes, branches, or non-overlapping path grants, followed by coordinator-owned integration and repository-wide verification.
+- The destructive-command hook now reads native `toolCall.args`, emits JSON `allow`/`deny`/`ask` decisions, and keeps legacy payload parsing for compatibility.
 
 ## 2026.7.26
 

--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,11 +1,18 @@
 {
   "$schema": "hooks/antigravity-hooks.schema.json",
-  "enabled": true,
-  "PreToolUse": [
-    {
-      "matcher": "run_command",
-      "command": "node .agents/hooks/validate-tool-call.mjs",
-      "timeout": 10
-    }
-  ]
+  "ag-kit-safety-gate": {
+    "enabled": true,
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .agents/hooks/validate-tool-call.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.agents/hooks/antigravity-doctor.mjs
+++ b/.agents/hooks/antigravity-doctor.mjs
@@ -17,9 +17,9 @@ function parseArgs(argv) {
   return options;
 }
 
-function readJson(file) {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
-}
+function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+function relative(root, file) { return path.relative(root, file).split(path.sep).join('/'); }
+function add(report, severity, phase, code, file, message) { report.findings.push({severity, phase, code, file, message}); }
 
 function frontmatter(file) {
   const text = fs.readFileSync(file, 'utf8');
@@ -29,60 +29,34 @@ function frontmatter(file) {
   const data = {};
   for (const line of text.slice(4, end).split(/\r?\n/)) {
     const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
-    if (!match) continue;
-    data[match[1]] = match[2].trim().replace(/^['"]|['"]$/g, '');
+    if (match) data[match[1]] = match[2].trim().replace(/^['"]|['"]$/g, '');
   }
   return data;
 }
 
 function markdownFiles(dir) {
   if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir)
-    .filter(name => name.endsWith('.md'))
-    .map(name => path.join(dir, name))
-    .sort();
+  return fs.readdirSync(dir).filter(name => name.endsWith('.md')).map(name => path.join(dir, name)).sort();
 }
 
 function skillFiles(dir) {
   if (!fs.existsSync(dir)) return [];
-  return fs.readdirSync(dir, {withFileTypes: true})
-    .filter(entry => entry.isDirectory())
-    .map(entry => path.join(dir, entry.name, 'SKILL.md'))
-    .filter(file => fs.existsSync(file))
-    .sort();
-}
-
-function add(report, severity, phase, code, file, message) {
-  report.findings.push({severity, phase, code, file, message});
-}
-
-function relative(root, file) {
-  return path.relative(root, file).split(path.sep).join('/');
+  return fs.readdirSync(dir, {withFileTypes: true}).filter(entry => entry.isDirectory()).map(entry => path.join(dir, entry.name, 'SKILL.md')).filter(fs.existsSync).sort();
 }
 
 function checkDiscovery(root, report) {
-  const agentsRoot = path.join(root, '.agents');
-  const groups = [
-    ['rules', markdownFiles(path.join(agentsRoot, 'rules')), ['trigger']],
-    ['workflows', markdownFiles(path.join(agentsRoot, 'workflows')), ['description']],
-    ['skills', skillFiles(path.join(agentsRoot, 'skills')), ['description']]
-  ];
-
-  for (const [kind, files, required] of groups) {
+  const agents = path.join(root, '.agents');
+  for (const [kind, files, fields] of [
+    ['rules', markdownFiles(path.join(agents, 'rules')), ['trigger']],
+    ['workflows', markdownFiles(path.join(agents, 'workflows')), ['description']],
+    ['skills', skillFiles(path.join(agents, 'skills')), ['description']]
+  ]) {
     report.counts[kind] = files.length;
-    if (files.length === 0) {
-      add(report, 'error', 'discovery', `${kind}.missing`, `.agents/${kind}`, `No Antigravity ${kind} were discovered.`);
-      continue;
-    }
+    if (!files.length) add(report, 'error', 'discovery', `${kind}.missing`, `.agents/${kind}`, `No Antigravity ${kind} were discovered.`);
     for (const file of files) {
       const meta = frontmatter(file);
-      if (!meta) {
-        add(report, 'error', 'discovery', `${kind}.frontmatter`, relative(root, file), 'Missing YAML frontmatter.');
-        continue;
-      }
-      for (const field of required) {
-        if (!meta[field]) add(report, 'error', 'discovery', `${kind}.required`, relative(root, file), `Missing frontmatter field: ${field}`);
-      }
+      if (!meta) add(report, 'error', 'discovery', `${kind}.frontmatter`, relative(root, file), 'Missing YAML frontmatter.');
+      else for (const field of fields) if (!meta[field]) add(report, 'error', 'discovery', `${kind}.required`, relative(root, file), `Missing frontmatter field: ${field}`);
     }
   }
 }
@@ -95,32 +69,16 @@ function walkStrings(value, callback) {
 
 function checkMcp(root, report) {
   const file = path.join(root, '.agents', 'mcp_config.json');
-  if (!fs.existsSync(file)) {
-    add(report, 'error', 'mcp', 'mcp.missing', '.agents/mcp_config.json', 'Workspace MCP configuration is missing.');
-    return;
-  }
   let config;
-  try {
-    config = readJson(file);
-  } catch (error) {
-    add(report, 'error', 'mcp', 'mcp.invalid_json', '.agents/mcp_config.json', error.message);
-    return;
-  }
+  try { config = readJson(file); } catch (error) { add(report, 'error', 'mcp', 'mcp.invalid', '.agents/mcp_config.json', error.message); return; }
   if (!config.mcpServers || typeof config.mcpServers !== 'object' || Array.isArray(config.mcpServers)) {
     add(report, 'error', 'mcp', 'mcp.servers', '.agents/mcp_config.json', 'mcpServers must be an object.');
     return;
   }
   report.counts.mcpServers = Object.keys(config.mcpServers).length;
   for (const [name, server] of Object.entries(config.mcpServers)) {
-    const valid = server && typeof server === 'object' && (
-      typeof server.command === 'string' || typeof server.serverURL === 'string' || typeof server.url === 'string'
-    );
-    if (!valid) add(report, 'error', 'mcp', 'mcp.server_shape', `.agents/mcp_config.json#${name}`, 'Server needs command, serverURL, or url.');
-    walkStrings(server, value => {
-      if (/YOUR_[A-Z0-9_]+|CHANGE_ME|<[^>]+>/.test(value)) {
-        add(report, 'warning', 'mcp', 'mcp.placeholder', `.agents/mcp_config.json#${name}`, 'Server contains an unresolved placeholder; configure it before enabling the server.');
-      }
-    });
+    if (!server || typeof server !== 'object' || !(typeof server.command === 'string' || typeof server.serverURL === 'string' || typeof server.url === 'string')) add(report, 'error', 'mcp', 'mcp.server_shape', `.agents/mcp_config.json#${name}`, 'Server needs command, serverURL, or url.');
+    walkStrings(server, value => { if (/YOUR_[A-Z0-9_]+|CHANGE_ME|<[^>]+>/.test(value)) add(report, 'warning', 'mcp', 'mcp.placeholder', `.agents/mcp_config.json#${name}`, 'Server contains an unresolved placeholder; configure it before enabling the server.'); });
   }
 }
 
@@ -129,127 +87,72 @@ function localCommandPath(command) {
   return match ? match[1] : null;
 }
 
+function validateHandler(root, report, ref, handler) {
+  if (!handler || typeof handler !== 'object') { add(report, 'error', 'hooks', 'hooks.handler_shape', ref, 'Hook handler must be an object.'); return; }
+  if (handler.type !== undefined && handler.type !== 'command') add(report, 'error', 'hooks', 'hooks.type', ref, 'Only command handlers are supported.');
+  if (typeof handler.command !== 'string' || !handler.command.trim()) add(report, 'error', 'hooks', 'hooks.command', ref, 'command is required.');
+  if (handler.timeout !== undefined && (!Number.isInteger(handler.timeout) || handler.timeout < 1 || handler.timeout > 300)) add(report, 'error', 'hooks', 'hooks.timeout', ref, 'timeout must be an integer from 1 to 300 seconds.');
+  const localPath = typeof handler.command === 'string' ? localCommandPath(handler.command) : null;
+  if (localPath && !fs.existsSync(path.join(root, localPath))) add(report, 'error', 'hooks', 'hooks.command_missing', ref, `Local hook target does not exist: ${localPath}`);
+}
+
 function checkHooks(root, report) {
   const file = path.join(root, '.agents', 'hooks.json');
-  if (!fs.existsSync(file)) {
-    add(report, 'error', 'hooks', 'hooks.missing', '.agents/hooks.json', 'Native Antigravity hooks configuration is missing.');
-    return;
-  }
   let config;
-  try {
-    config = readJson(file);
-  } catch (error) {
-    add(report, 'error', 'hooks', 'hooks.invalid_json', '.agents/hooks.json', error.message);
-    return;
-  }
-  if (typeof config.enabled !== 'boolean') add(report, 'error', 'hooks', 'hooks.enabled', '.agents/hooks.json', 'enabled must be boolean.');
-  const events = ['PreToolUse', 'PostToolUse', 'PreInvocation', 'PostInvocation', 'Stop'];
+  try { config = readJson(file); } catch (error) { add(report, 'error', 'hooks', 'hooks.invalid_json', '.agents/hooks.json', error.message); return; }
   let total = 0;
-  for (const event of events) {
-    if (config[event] === undefined) continue;
-    if (!Array.isArray(config[event])) {
-      add(report, 'error', 'hooks', 'hooks.event_shape', `.agents/hooks.json#${event}`, `${event} must be an array.`);
-      continue;
+  for (const [name, definition] of Object.entries(config)) {
+    if (name === '$schema') continue;
+    const base = `.agents/hooks.json#${name}`;
+    if (!definition || typeof definition !== 'object' || Array.isArray(definition)) { add(report, 'error', 'hooks', 'hooks.definition_shape', base, 'Named hook definition must be an object.'); continue; }
+    if (definition.enabled !== undefined && typeof definition.enabled !== 'boolean') add(report, 'error', 'hooks', 'hooks.enabled', base, 'enabled must be boolean.');
+    for (const event of ['PreToolUse', 'PostToolUse']) {
+      if (definition[event] === undefined) continue;
+      if (!Array.isArray(definition[event])) { add(report, 'error', 'hooks', 'hooks.event_shape', `${base}.${event}`, `${event} must be an array.`); continue; }
+      definition[event].forEach((entry, index) => {
+        const ref = `${base}.${event}[${index}]`;
+        if (!entry || typeof entry !== 'object' || typeof entry.matcher !== 'string' || !Array.isArray(entry.hooks) || !entry.hooks.length) { add(report, 'error', 'hooks', 'hooks.tool_event_shape', ref, `${event} requires matcher and a non-empty hooks array.`); return; }
+        entry.hooks.forEach((handler, handlerIndex) => { total += 1; validateHandler(root, report, `${ref}.hooks[${handlerIndex}]`, handler); });
+      });
     }
-    for (const [index, hook] of config[event].entries()) {
-      total += 1;
-      const ref = `.agents/hooks.json#${event}[${index}]`;
-      if (!hook || typeof hook !== 'object') {
-        add(report, 'error', 'hooks', 'hooks.hook_shape', ref, 'Hook must be an object.');
-        continue;
-      }
-      if (typeof hook.matcher !== 'string' || !hook.matcher.trim()) add(report, 'error', 'hooks', 'hooks.matcher', ref, 'matcher is required.');
-      if (typeof hook.command !== 'string' || !hook.command.trim()) add(report, 'error', 'hooks', 'hooks.command', ref, 'command is required.');
-      if (!Number.isInteger(hook.timeout) || hook.timeout < 1 || hook.timeout > 300) add(report, 'error', 'hooks', 'hooks.timeout', ref, 'timeout must be an integer from 1 to 300 seconds.');
-      const localPath = typeof hook.command === 'string' ? localCommandPath(hook.command) : null;
-      if (localPath && !fs.existsSync(path.join(root, localPath))) add(report, 'error', 'hooks', 'hooks.command_missing', ref, `Local hook target does not exist: ${localPath}`);
+    for (const event of ['PreInvocation', 'PostInvocation', 'Stop']) {
+      if (definition[event] === undefined) continue;
+      if (!Array.isArray(definition[event])) { add(report, 'error', 'hooks', 'hooks.event_shape', `${base}.${event}`, `${event} must be an array.`); continue; }
+      definition[event].forEach((handler, index) => { total += 1; validateHandler(root, report, `${base}.${event}[${index}]`, handler); });
     }
   }
   report.counts.hooks = total;
-  if (total === 0) add(report, 'warning', 'hooks', 'hooks.empty', '.agents/hooks.json', 'No native hooks are registered.');
+  if (!total) add(report, 'warning', 'hooks', 'hooks.empty', '.agents/hooks.json', 'No native hooks are registered.');
 }
 
 function checkOrchestration(root, report, contract) {
   const cfg = contract?.phases?.orchestration ?? {};
-  const groups = [
+  for (const [kind, names, resolve] of [
     ['workflow', cfg.workflows ?? [], name => path.join(root, '.agents', 'workflows', `${name}.md`)],
     ['agent', cfg.agents ?? [], name => path.join(root, '.agents', 'agent', `${name}.md`)],
     ['skill', cfg.skills ?? [], name => path.join(root, '.agents', 'skills', name, 'SKILL.md')]
-  ];
-  for (const [kind, names, resolve] of groups) {
-    for (const name of names) {
-      const file = resolve(name);
-      if (!fs.existsSync(file)) add(report, 'error', 'orchestration', `orchestration.${kind}_missing`, relative(root, file), `Required Antigravity ${kind} is missing.`);
-    }
-  }
+  ]) for (const name of names) { const file = resolve(name); if (!fs.existsSync(file)) add(report, 'error', 'orchestration', `orchestration.${kind}_missing`, relative(root, file), `Required Antigravity ${kind} is missing.`); }
 }
 
 function checkPlugin(root, report) {
-  const files = [
-    '.agents/hooks/build-plugin.mjs',
-    '.agents/hooks/plugin/GEMINI.md',
-    '.agents/hooks/plugin/gemini-extension.template.json'
-  ];
-  for (const file of files) {
-    if (!fs.existsSync(path.join(root, file))) add(report, 'error', 'plugin', 'plugin.file_missing', file, 'Plugin packaging input is missing.');
-  }
+  for (const file of ['.agents/hooks/build-plugin.mjs', '.agents/hooks/plugin/GEMINI.md', '.agents/hooks/plugin/gemini-extension.template.json']) if (!fs.existsSync(path.join(root, file))) add(report, 'error', 'plugin', 'plugin.file_missing', file, 'Plugin packaging input is missing.');
 }
 
 function checkValidation(root, report) {
-  const requiredFiles = [
-    '.agents/hooks/tests/antigravity.test.mjs',
-    'MIGRATION.md',
-    'SECURITY.md'
-  ];
-  for (const file of requiredFiles) {
-    if (!fs.existsSync(path.join(root, file))) add(report, 'error', 'validation', 'validation.file_missing', file, 'Production validation or operator documentation is missing.');
-  }
-
-  const versionFiles = [
-    ['.agents/VERSION', value => value.trim()],
-    ['package.json', value => JSON.parse(value).version],
-    ['cli/package.json', value => JSON.parse(value).version],
-    ['web/package.json', value => JSON.parse(value).version]
-  ];
+  for (const file of ['.agents/hooks/tests/antigravity.test.mjs', 'MIGRATION.md', 'SECURITY.md']) if (!fs.existsSync(path.join(root, file))) add(report, 'error', 'validation', 'validation.file_missing', file, 'Production validation or operator documentation is missing.');
+  const specs = [['.agents/VERSION', value => value.trim()], ['package.json', value => JSON.parse(value).version], ['cli/package.json', value => JSON.parse(value).version], ['web/package.json', value => JSON.parse(value).version]];
   const versions = [];
-  for (const [file, parse] of versionFiles) {
-    const target = path.join(root, file);
-    if (!fs.existsSync(target)) {
-      add(report, 'error', 'validation', 'validation.version_missing', file, 'Version source is missing.');
-      continue;
-    }
-    try {
-      versions.push([file, parse(fs.readFileSync(target, 'utf8'))]);
-    } catch (error) {
-      add(report, 'error', 'validation', 'validation.version_invalid', file, error.message);
-    }
-  }
-  const unique = new Set(versions.map(([, value]) => value));
-  if (unique.size > 1) add(report, 'error', 'validation', 'validation.version_mismatch', 'VERSION', `Release versions are not synchronized: ${versions.map(([file, value]) => `${file}=${value}`).join(', ')}`);
+  for (const [file, parse] of specs) try { versions.push([file, parse(fs.readFileSync(path.join(root, file), 'utf8'))]); } catch (error) { add(report, 'error', 'validation', 'validation.version_invalid', file, error.message); }
+  if (new Set(versions.map(([, value]) => value)).size > 1) add(report, 'error', 'validation', 'validation.version_mismatch', 'VERSION', `Release versions are not synchronized: ${versions.map(([file, value]) => `${file}=${value}`).join(', ')}`);
   report.counts.releaseVersions = Object.fromEntries(versions);
 }
 
 export function diagnose(root) {
   const report = {runtime: 'antigravity', root, passed: true, counts: {}, phases: {}, findings: []};
-  const contractFile = path.join(root, '.agents', 'antigravity.json');
   let contract;
-  try {
-    contract = readJson(contractFile);
-    if (contract.runtime !== 'antigravity') add(report, 'error', 'discovery', 'contract.runtime', '.agents/antigravity.json', 'runtime must be antigravity.');
-  } catch (error) {
-    add(report, 'error', 'discovery', 'contract.invalid', '.agents/antigravity.json', error.message);
-  }
-
-  checkDiscovery(root, report);
-  checkMcp(root, report);
-  checkHooks(root, report);
-  checkOrchestration(root, report, contract);
-  checkPlugin(root, report);
-  checkValidation(root, report);
-
-  for (const phase of ['discovery', 'mcp', 'hooks', 'orchestration', 'plugin', 'validation']) {
-    report.phases[phase] = !report.findings.some(item => item.phase === phase && item.severity === 'error');
-  }
+  try { contract = readJson(path.join(root, '.agents', 'antigravity.json')); if (contract.runtime !== 'antigravity') add(report, 'error', 'discovery', 'contract.runtime', '.agents/antigravity.json', 'runtime must be antigravity.'); } catch (error) { add(report, 'error', 'discovery', 'contract.invalid', '.agents/antigravity.json', error.message); }
+  checkDiscovery(root, report); checkMcp(root, report); checkHooks(root, report); checkOrchestration(root, report, contract); checkPlugin(root, report); checkValidation(root, report);
+  for (const phase of ['discovery', 'mcp', 'hooks', 'orchestration', 'plugin', 'validation']) report.phases[phase] = !report.findings.some(item => item.phase === phase && item.severity === 'error');
   report.passed = !report.findings.some(item => item.severity === 'error');
   return report;
 }
@@ -265,17 +168,9 @@ function printHuman(report) {
 if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     const options = parseArgs(process.argv.slice(2));
-    if (options.help) {
-      console.log('Usage: node .agents/hooks/antigravity-doctor.mjs [--root PATH] [--json] [--strict]');
-      process.exit(0);
-    }
+    if (options.help) { console.log('Usage: node .agents/hooks/antigravity-doctor.mjs [--root PATH] [--json] [--strict]'); process.exit(0); }
     const report = diagnose(options.root);
-    if (options.json) console.log(JSON.stringify(report, null, 2));
-    else printHuman(report);
-    const hasWarnings = report.findings.some(item => item.severity === 'warning');
-    process.exitCode = report.passed && !(options.strict && hasWarnings) ? 0 : 1;
-  } catch (error) {
-    console.error(error.message);
-    process.exitCode = 2;
-  }
+    if (options.json) console.log(JSON.stringify(report, null, 2)); else printHuman(report);
+    process.exitCode = report.passed && !(options.strict && report.findings.some(item => item.severity === 'warning')) ? 0 : 1;
+  } catch (error) { console.error(error.message); process.exitCode = 2; }
 }

--- a/.agents/hooks/antigravity-hooks.schema.json
+++ b/.agents/hooks/antigravity-hooks.schema.json
@@ -3,42 +3,64 @@
   "$id": "https://ag-kit.dev/schemas/antigravity-hooks.schema.json",
   "title": "AG Kit Antigravity Native Hooks",
   "type": "object",
-  "required": ["enabled"],
-  "properties": {
-    "$schema": {"type": "string"},
-    "enabled": {"type": "boolean"},
-    "PreToolUse": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/hook"}
+  "propertyNames": {"minLength": 1},
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "enabled": {"type": "boolean"},
+      "PreToolUse": {
+        "type": "array",
+        "items": {"$ref": "#/$defs/toolEvent"}
+      },
+      "PostToolUse": {
+        "type": "array",
+        "items": {"$ref": "#/$defs/toolEvent"}
+      },
+      "PreInvocation": {
+        "type": "array",
+        "items": {"$ref": "#/$defs/handler"}
+      },
+      "PostInvocation": {
+        "type": "array",
+        "items": {"$ref": "#/$defs/handler"}
+      },
+      "Stop": {
+        "type": "array",
+        "items": {"$ref": "#/$defs/handler"}
+      }
     },
-    "PostToolUse": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/hook"}
-    },
-    "PreInvocation": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/hook"}
-    },
-    "PostInvocation": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/hook"}
-    },
-    "Stop": {
-      "type": "array",
-      "items": {"$ref": "#/$defs/hook"}
-    }
+    "additionalProperties": false,
+    "anyOf": [
+      {"required": ["PreToolUse"]},
+      {"required": ["PostToolUse"]},
+      {"required": ["PreInvocation"]},
+      {"required": ["PostInvocation"]},
+      {"required": ["Stop"]}
+    ]
   },
   "$defs": {
-    "hook": {
+    "toolEvent": {
       "type": "object",
-      "required": ["matcher", "command", "timeout"],
+      "required": ["matcher", "hooks"],
       "properties": {
-        "matcher": {"type": "string", "minLength": 1},
+        "matcher": {"type": "string"},
+        "hooks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/handler"}
+        }
+      },
+      "additionalProperties": false
+    },
+    "handler": {
+      "type": "object",
+      "required": ["command"],
+      "properties": {
+        "type": {"const": "command"},
         "command": {"type": "string", "minLength": 1},
         "timeout": {"type": "integer", "minimum": 1, "maximum": 300}
       },
       "additionalProperties": false
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/.agents/hooks/tests/antigravity.test.mjs
+++ b/.agents/hooks/tests/antigravity.test.mjs
@@ -7,45 +7,47 @@ import test from 'node:test';
 
 import {diagnose} from '../antigravity-doctor.mjs';
 import {buildPlugin} from '../build-plugin.mjs';
-import {evaluateCommand, extractCommand} from '../validate-tool-call.mjs';
+import {decisionForPayload, evaluateCommand, extractCommand} from '../validate-tool-call.mjs';
 import {planSync} from '../sync-mcp.mjs';
 
 const root = path.resolve(import.meta.dirname, '../../..');
 
-test('extracts Antigravity CommandLine payload', () => {
+test('extracts native and legacy Antigravity command payloads', () => {
+  assert.equal(extractCommand({toolCall: {args: {CommandLine: 'npm test'}}}), 'npm test');
   assert.equal(extractCommand({tool_args: {CommandLine: 'npm test'}}), 'npm test');
 });
 
-test('allows normal project cleanup', () => {
-  assert.equal(evaluateCommand('rm -rf ./dist').allowed, true);
-  assert.equal(evaluateCommand('rm -rf node_modules').allowed, true);
+test('allows normal cleanup and denies destructive commands', () => {
+  assert.equal(evaluateCommand('rm -rf ./dist').decision, 'allow');
+  assert.equal(evaluateCommand('rm -rf node_modules').decision, 'allow');
+  assert.equal(evaluateCommand('sudo rm -rf /').decision, 'deny');
+  assert.equal(evaluateCommand('mkfs.ext4 /dev/sda1').decision, 'deny');
+  assert.equal(evaluateCommand('dd if=/dev/zero of=/dev/sda').decision, 'deny');
+  assert.equal(evaluateCommand('format C:').decision, 'deny');
 });
 
-test('blocks destructive root and disk commands', () => {
-  assert.equal(evaluateCommand('sudo rm -rf /').allowed, false);
-  assert.equal(evaluateCommand('mkfs.ext4 /dev/sda1').allowed, false);
-  assert.equal(evaluateCommand('dd if=/dev/zero of=/dev/sda').allowed, false);
-  assert.equal(evaluateCommand('format C:').allowed, false);
+test('returns the native JSON decision contract', () => {
+  assert.equal(decisionForPayload({toolCall: {args: {CommandLine: 'npm test'}}}).decision, 'allow');
+  assert.equal(decisionForPayload({toolCall: {args: {CommandLine: 'rm -rf /'}}}).decision, 'deny');
+  assert.equal(decisionForPayload({}).decision, 'allow');
 });
 
-test('hook process returns non-zero for blocked command', () => {
-  const result = spawnSync(process.execPath, [path.join(root, '.agents/hooks/validate-tool-call.mjs')], {
-    input: JSON.stringify({tool_args: {CommandLine: 'rm -rf /'}}),
-    encoding: 'utf8'
-  });
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, /BLOCKED by AG Kit/);
+test('hook process emits JSON and exits zero for allow, deny, and invalid input', () => {
+  for (const [input, decision] of [
+    [JSON.stringify({toolCall: {args: {CommandLine: 'npm test'}}}), 'allow'],
+    [JSON.stringify({toolCall: {args: {CommandLine: 'rm -rf /'}}}), 'deny'],
+    ['not-json', 'ask']
+  ]) {
+    const result = spawnSync(process.execPath, [path.join(root, '.agents/hooks/validate-tool-call.mjs')], {input, encoding: 'utf8'});
+    assert.equal(result.status, 0);
+    assert.equal(JSON.parse(result.stdout).decision, decision);
+  }
 });
 
 test('doctor recognizes all six implementation phases', () => {
   const report = diagnose(root);
   assert.equal(report.runtime, 'antigravity');
-  assert.equal(report.phases.discovery, true);
-  assert.equal(report.phases.mcp, true);
-  assert.equal(report.phases.hooks, true);
-  assert.equal(report.phases.orchestration, true);
-  assert.equal(report.phases.plugin, true);
-  assert.equal(report.phases.validation, true);
+  for (const phase of ['discovery', 'mcp', 'hooks', 'orchestration', 'plugin', 'validation']) assert.equal(report.phases[phase], true);
   assert.equal(report.passed, true);
 });
 
@@ -61,20 +63,14 @@ test('MCP sync detects placeholders and plans without writing', () => {
   assert.ok(Object.keys(plan.workspace.mcpServers).length > 0);
 });
 
-test('plugin builder creates manifest, commands, skills, and hook', () => {
+test('plugin builder creates deterministic inventory', () => {
   const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-kit-plugin-'));
   const output = path.join(temporary, 'plugin');
   const manifest = buildPlugin(root, output);
   assert.equal(manifest.runtime, 'antigravity');
   assert.ok(manifest.counts.skills > 0);
-  assert.ok(manifest.counts.workflows > 0);
-  assert.ok(fs.existsSync(path.join(output, 'gemini-extension.json')));
-  assert.ok(fs.existsSync(path.join(output, 'commands/ag-kit/orchestrate.toml')));
-  assert.ok(fs.existsSync(path.join(output, 'hooks/hooks.json')));
-  assert.ok(fs.existsSync(path.join(output, 'PLUGIN_CONTENTS.json')));
-  const firstInventory = fs.readFileSync(path.join(output, 'PLUGIN_CONTENTS.json'), 'utf8');
+  const first = fs.readFileSync(path.join(output, 'PLUGIN_CONTENTS.json'), 'utf8');
   buildPlugin(root, output);
-  const secondInventory = fs.readFileSync(path.join(output, 'PLUGIN_CONTENTS.json'), 'utf8');
-  assert.equal(secondInventory, firstInventory);
+  assert.equal(fs.readFileSync(path.join(output, 'PLUGIN_CONTENTS.json'), 'utf8'), first);
   fs.rmSync(temporary, {recursive: true, force: true});
 });

--- a/.agents/hooks/validate-tool-call.mjs
+++ b/.agents/hooks/validate-tool-call.mjs
@@ -3,31 +3,11 @@
 import process from 'node:process';
 
 const BLOCK_RULES = [
-  {
-    id: 'unix-root-delete',
-    pattern: /(?:^|[;&|]\s*)(?:sudo\s+)?rm\s+(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*)\s+(?:--\s+)?\/(?:\*|\s|$)/i,
-    message: 'recursive deletion of the filesystem root'
-  },
-  {
-    id: 'filesystem-format',
-    pattern: /(?:^|[;&|]\s*)(?:sudo\s+)?mkfs(?:\.[A-Za-z0-9_-]+)?\b/i,
-    message: 'filesystem formatting command'
-  },
-  {
-    id: 'raw-disk-overwrite',
-    pattern: /\bdd\b[^\n]*\bof=\/dev\/(?:sd|nvme|vd|xvd)[A-Za-z0-9_-]*/i,
-    message: 'raw disk overwrite'
-  },
-  {
-    id: 'windows-drive-format',
-    pattern: /(?:^|[;&|]\s*)format(?:\.com)?\s+[A-Za-z]:/i,
-    message: 'Windows drive format'
-  },
-  {
-    id: 'windows-root-delete',
-    pattern: /remove-item\b[^\n]*-(?:recurse|r)\b[^\n]*-(?:force|fo)\b[^\n]*(?:[A-Za-z]:\\(?:\s|$)|[A-Za-z]:\\\*)/i,
-    message: 'recursive deletion of a Windows drive root'
-  }
+  {id: 'unix-root-delete', pattern: /(?:^|[;&|]\s*)(?:sudo\s+)?rm\s+(?:-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*|-[A-Za-z]*f[A-Za-z]*r[A-Za-z]*)\s+(?:--\s+)?\/(?:\*|\s|$)/i, message: 'recursive deletion of the filesystem root'},
+  {id: 'filesystem-format', pattern: /(?:^|[;&|]\s*)(?:sudo\s+)?mkfs(?:\.[A-Za-z0-9_-]+)?\b/i, message: 'filesystem formatting command'},
+  {id: 'raw-disk-overwrite', pattern: /\bdd\b[^\n]*\bof=\/dev\/(?:sd|nvme|vd|xvd)[A-Za-z0-9_-]*/i, message: 'raw disk overwrite'},
+  {id: 'windows-drive-format', pattern: /(?:^|[;&|]\s*)format(?:\.com)?\s+[A-Za-z]:/i, message: 'Windows drive format'},
+  {id: 'windows-root-delete', pattern: /remove-item\b[^\n]*-(?:recurse|r)\b[^\n]*-(?:force|fo)\b[^\n]*(?:[A-Za-z]:\\(?:\s|$)|[A-Za-z]:\\\*)/i, message: 'recursive deletion of a Windows drive root'}
 ];
 
 function readStdin() {
@@ -36,9 +16,7 @@ function readStdin() {
     process.stdin.setEncoding('utf8');
     process.stdin.on('data', chunk => {
       input += chunk;
-      if (input.length > 1024 * 1024) {
-        reject(new Error('hook payload exceeds 1 MiB'));
-      }
+      if (input.length > 1024 * 1024) reject(new Error('hook payload exceeds 1 MiB'));
     });
     process.stdin.on('end', () => resolve(input));
     process.stdin.on('error', reject);
@@ -46,19 +24,21 @@ function readStdin() {
 }
 
 function firstString(...values) {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim()) return value.trim();
-  }
-  return '';
+  return values.find(value => typeof value === 'string' && value.trim())?.trim() ?? '';
 }
 
 export function extractCommand(payload) {
-  const args = payload?.tool_args ?? payload?.toolArgs ?? payload?.arguments ?? {};
+  const nativeArgs = payload?.toolCall?.args ?? {};
+  const legacyArgs = payload?.tool_args ?? payload?.toolArgs ?? payload?.arguments ?? {};
   return firstString(
-    args.CommandLine,
-    args.commandLine,
-    args.command,
-    args.cmd,
+    nativeArgs.CommandLine,
+    nativeArgs.commandLine,
+    nativeArgs.command,
+    nativeArgs.cmd,
+    legacyArgs.CommandLine,
+    legacyArgs.commandLine,
+    legacyArgs.command,
+    legacyArgs.cmd,
     payload?.command,
     payload?.cmd
   );
@@ -66,46 +46,30 @@ export function extractCommand(payload) {
 
 export function evaluateCommand(command) {
   for (const rule of BLOCK_RULES) {
-    if (rule.pattern.test(command)) {
-      return {allowed: false, rule: rule.id, reason: rule.message};
-    }
+    if (rule.pattern.test(command)) return {decision: 'deny', rule: rule.id, reason: rule.message};
   }
-  return {allowed: true, rule: null, reason: 'no destructive command pattern matched'};
+  return {decision: 'allow', rule: null, reason: 'Command passed the destructive-operation gate.'};
+}
+
+export function decisionForPayload(payload) {
+  const command = extractCommand(payload);
+  if (!command) return {decision: 'allow', reason: 'No command payload was present.'};
+  const result = evaluateCommand(command);
+  return result.decision === 'deny'
+    ? {decision: 'deny', reason: `AG Kit blocked ${result.reason}.`}
+    : {decision: 'allow', reason: result.reason};
 }
 
 async function main() {
-  let raw;
   try {
-    raw = await readStdin();
+    const raw = await readStdin();
+    const payload = JSON.parse(raw || '{}');
+    process.stdout.write(`${JSON.stringify(decisionForPayload(payload))}\n`);
+    return 0;
   } catch (error) {
-    console.error(`AG Kit hook warning: ${error.message}`);
+    process.stdout.write(`${JSON.stringify({decision: 'ask', reason: `AG Kit could not validate the tool call: ${error.message}`})}\n`);
     return 0;
   }
-
-  let payload;
-  try {
-    payload = JSON.parse(raw || '{}');
-  } catch {
-    console.error('AG Kit hook warning: Antigravity sent invalid JSON; allowing the call to avoid a runtime-wide lockout.');
-    return 0;
-  }
-
-  const command = extractCommand(payload);
-  if (!command) {
-    console.log('AG Kit hook: no command payload detected; allowed.');
-    return 0;
-  }
-
-  const result = evaluateCommand(command);
-  if (!result.allowed) {
-    console.error(`BLOCKED by AG Kit (${result.rule}): ${result.reason}.`);
-    return 1;
-  }
-
-  console.log('APPROVED by AG Kit: command passed the destructive-operation gate.');
-  return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exitCode = await main();
-}
+if (import.meta.url === `file://${process.argv[1]}`) process.exitCode = await main();


### PR DESCRIPTION
## Summary

Aligns AG Kit's Antigravity safety hook with the current official native hooks contract.

The repository previously used a flat `hooks.json` shape and an exit-code/text-output handler contract. Current Antigravity documentation defines named hook groups, nested command handlers for tool events, camelCase `toolCall.args` input, and JSON decisions on stdout.

This PR remains **Draft**. It does not merge, publish, release, deploy, enable auto-merge, or push to `main`.

## Official sources

- Antigravity Hooks configuration, event structure, tool names, and input/output contract: https://antigravity.google/docs/hooks
- Antigravity plugin/customization model: https://antigravity.google/docs/ide/plugins
- Antigravity CLI reference for hooks, permissions, agents, and tasks: https://antigravity.google/docs/cli-reference

## Rationale

The existing hook stack could pass AG Kit's own Doctor and tests while not matching the current runtime contract:

- `hooks.json` used top-level `enabled` and event keys instead of named hook definitions;
- `PreToolUse` entries placed `command` directly beside `matcher` instead of nesting command handlers under `hooks`;
- the handler primarily read legacy `tool_args.CommandLine` rather than native `toolCall.args.CommandLine`;
- blocking relied on process exit code and stderr text rather than the documented JSON `decision` response.

That creates a production safety risk: a destructive-command gate may be undiscovered, ignored, or interpreted incorrectly by the runtime.

## Changed files

- `.agents/hooks.json`
  - Uses a named `ag-kit-safety-gate` definition.
  - Nests the command handler under `PreToolUse[].hooks`.
- `.agents/hooks/antigravity-hooks.schema.json`
  - Validates named hook definitions, tool-event matchers, nested handlers, invocation/stop handlers, timeout bounds, and command-only handler types.
- `.agents/hooks/validate-tool-call.mjs`
  - Reads native `toolCall.args` first.
  - Retains legacy payload parsing for backward compatibility.
  - Emits JSON `allow`, `deny`, or `ask` decisions on stdout.
  - Uses `ask` for malformed or oversized payloads instead of silently allowing them.
- `.agents/hooks/antigravity-doctor.mjs`
  - Validates the current named-hook structure and local handler paths.
- `.agents/hooks/tests/antigravity.test.mjs`
  - Covers native and legacy payload extraction, JSON decisions, blocked commands, malformed input, and zero-exit JSON behavior.
- `.agents/CHANGELOG.md`
  - Records the compatibility and security correction under `Unreleased`.

## Compatibility and migration

- Existing command-blocking rules remain unchanged.
- Legacy `tool_args`, `toolArgs`, and `arguments` payloads remain accepted.
- Native Antigravity runtimes should use `toolCall.args` and JSON decisions.
- Hook configuration consumers that implemented AG Kit's previous flat schema must migrate to named hook definitions with nested `hooks` arrays.
- No agent, skill, workflow, rule, command, or public CLI interface is renamed.
- The AG Kit release version remains unchanged while the PR is in draft.

## Security considerations

- Destructive root/disk operations continue to be denied.
- Missing command payloads are allowed because the matcher is scoped to `run_command`, but malformed JSON or oversized hook input now produces `ask` for explicit review rather than fail-open execution.
- The handler returns only decision metadata and does not echo command content, workspace paths, transcripts, credentials, or other hook payload data.
- Legacy parsing is compatibility-only and does not expand permissions.

## Impact and risk

- **Expected impact:** the safety gate is discoverable and enforceable by current Antigravity runtimes.
- **Security impact:** high-value correction because the previous format could result in an ineffective pre-tool safety gate.
- **Runtime risk:** low to moderate; the hook configuration shape changes, but it follows the current official contract and retains legacy input parsing.
- **Compatibility risk:** consumers of the old AG Kit-specific flat hook shape require migration.

## Test plan

- `node --test .agents/hooks/tests/antigravity.test.mjs`
- `node .agents/hooks/antigravity-doctor.mjs --strict`
- `python .agents/scripts/generate_manifest.py .agents --check`
- `python .agents/scripts/dependency_graph.py .agents --check`
- `python .agents/scripts/validate_kit.py .agents`
- `python -m unittest discover -s .agents/scripts/tests -v`
- `python -m compileall -q .agents`
- CLI tests/package validation and production dependency audit
- web lint, typecheck, build, and production dependency audit

## Current CI status

- `Antigravity Compatibility`: **passed**.
- `Dependency Review`: **passed**.
- CLI tests/package validation: **passed**.
- Web lint/typecheck/build/audit: **passed**.
- Toolkit validation: **failed only because `.agents/manifest.lock.json` is stale** after the hook/changelog changes.

The failing generated-metadata check is caused by this PR and must be resolved with the repository's canonical `generate_manifest.py` output before the PR can leave Draft.

## Unresolved questions / draft blockers

- Regenerate `.agents/manifest.lock.json` with the repository's canonical generator after the final hook files settle; the draft intentionally leaves release metadata unchanged until validation is complete.
- Confirm behavior in an installed Antigravity runtime in addition to schema/unit coverage before marking the PR ready.
